### PR TITLE
Really need to include pcap-int.h after system includes 

### DIFF
--- a/search.c
+++ b/search.c
@@ -29,15 +29,16 @@
 
 #include <sys/types.h>
 
-#include <pcap.h>
-#ifdef HAVE_PCAP_INT_H
-#include <pcap-int.h>		/* because we are directly reading the file */
-#endif
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>
 #include <unistd.h>
+
+#include <pcap.h>
+#ifdef HAVE_PCAP_INT_H
+#include <pcap-int.h>		/* because we are directly reading the file */
+#endif
 
 #ifdef HAVE_OS_PROTO_H
 #include "os-proto.h"


### PR DESCRIPTION
or else libpcap's portability.h causes things to go off the rails.

On FreeBSD 11.3-RELEASE the conflict is with string.h:

```
In file included from ./search.c:38:
/usr/include/string.h:92:9: error: expected ')'
size_t   strlcat(char * __restrict, const char * __restrict, size_t);
         ^
/usr/src/contrib/libpcap/portability.h:86:24: note: expanded from macro 'strlcat'
        strncat((x), (y), (z) - strlen((x)) - 1)
                              ^
/usr/include/string.h:92:9: note: to match this '('
/usr/src/contrib/libpcap/portability.h:86:9: note: expanded from macro 'strlcat'
        strncat((x), (y), (z) - strlen((x)) - 1)
               ^
In file included from ./search.c:38:
/usr/include/string.h:99:7: error: conflicting types for 'strncat'
char    *strncat(char * __restrict, const char * __restrict, size_t);
         ^
/usr/include/string.h:92:9: note: previous declaration is here
size_t   strlcat(char * __restrict, const char * __restrict, size_t);
         ^
/usr/src/contrib/libpcap/portability.h:86:2: note: expanded from macro 'strlcat'
        strncat((x), (y), (z) - strlen((x)) - 1)
        ^
2 errors generated.
*** [search.o] Error code 1

make[1]: stopped in /wrkdirs/usr/ports/net/tcpslice/work/tcpslice-2837b72
1 error

make[1]: stopped in /wrkdirs/usr/ports/net/tcpslice/work/tcpslice-2837b72
===> Compilation failed unexpectedly.
Try to set MAKE_JOBS_UNSAFE=yes and rebuild before reporting the failure to
the maintainer.
*** Error code 1

Stop.
make: stopped in /usr/ports/net/tcpslice
```