### PR TITLE
instrument-functions: leave space for a terminating '\0'.

### DIFF
--- a/instrument-functions.c
+++ b/instrument-functions.c
@@ -103,18 +103,26 @@ static void print_debug(void *this_fn, void *call_site, action_type action)
 
 	/* If no errors, this block should be executed one time */
 	if (!abfd) {
-		char pgm_name[1024];
+/*
+ * Should this be some system #define?
+ *
+ * Or can we do a stat() on the symlink and get the path length from
+ * that, and allocate it dynamically?
+ */
+#define READLINK_PATH_LEN	1024
+/* +1 for a trailing '\0', which readlink() doesn't provide */
+		char pgm_name[READLINK_PATH_LEN + 1];
 		long symsize;
 
 		if (!stat(ND_FILE_FLAG_GLOBAL, &statbuf))
 			print_only_global = 1;
 
-		ssize_t ret = readlink("/proc/self/exe", pgm_name, sizeof(pgm_name));
+		ssize_t ret = readlink("/proc/self/exe", pgm_name, READLINK_PATH_LEN);
 		if (ret == -1) {
 			perror("failed to find executable\n");
 			return;
 		}
-		pgm_name[ret] = 0;
+		pgm_name[ret] = '\0';
 
 		bfd_init();
 


### PR DESCRIPTION
readlink() just reads the raw symlink data, which doesn't include a terminating '\0'.  We must leave space for the '\0', and *not* tell readlink() about that, so that, when we use its return value to tell us where to put the '\0', it doesn't return a value equal to the full size of the buffer, meaning we'd put the '\0' *after* the end of the buffer.

Fixes Coverity CID 310987.