### PR TITLE
Include <config.h> unconditionally

### DIFF
--- a/gmt2local.c
+++ b/gmt2local.c
@@ -19,9 +19,7 @@
  * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
  */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include <sys/types.h>
 #include <sys/time.h>

--- a/gwtm2secs.c
+++ b/gwtm2secs.c
@@ -23,9 +23,7 @@
  * gwtm2secs.c - convert "tm" structs for Greenwich time to Unix timestamp
  */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include <sys/types.h>
 

--- a/search.c
+++ b/search.c
@@ -23,9 +23,7 @@
  * search.c - supports fast searching through pcap files for timestamps
  */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include <sys/types.h>
 

--- a/seek-tell.c
+++ b/seek-tell.c
@@ -21,9 +21,7 @@
  * 64-bit-offset fseek and ftell.
  */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 // For fseeko() and ftello().
 #if defined(__SUNPRO_C) && ! defined(__EXTENSIONS__)

--- a/sessions.c
+++ b/sessions.c
@@ -43,9 +43,7 @@
  *  - tcp_callback() is called upon reception of correct TCP data
  */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/tcpslice.c
+++ b/tcpslice.c
@@ -23,9 +23,7 @@
  * tcpslice - extract pieces of and/or glue together pcap files
  */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 // For fileno() and getopt().
 #if defined(__SUNPRO_C) && ! defined(__EXTENSIONS__)

--- a/util.c
+++ b/util.c
@@ -19,9 +19,7 @@
  * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
  */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include <stdio.h>
 #include <stdlib.h>


### PR DESCRIPTION
Builds using Autotools or CMake generate config.h, thus remove the '#ifdef HAVE_CONFIG_H'/'#endif'.