### PR TITLE
Makefile.in: Update the .c.o build rule

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -62,12 +62,8 @@ INSTALL_DATA = @INSTALL_DATA@
 
 DEPENDENCY_CFLAG = @DEPENDENCY_CFLAG@
 
-# Explicitly define compilation rule since SunOS 4's make doesn't like gcc.
-# Also, gcc does not remove the .o before forking 'as', which can be a
-# problem if you don't own the file but can write to the directory.
 .c.o:
-	@rm -f $@
-	$(CC) $(FULL_CFLAGS) -c $(srcdir)/$*.c
+	$(CC) $(FULL_CFLAGS) -c -o $@ $<
 
 CSRC =	tcpslice.c gmt2local.c gwtm2secs.c search.c \
 	seek-tell.c sessions.c util.c


### PR DESCRIPTION
Don't use the hacks for the rather old SunOS 4.

It's helps to do VPATH builds, e.g. 32-bit, 64-bit in two directories.
(https://www.gnu.org/software/automake/manual/html_node/VPATH-Builds.html)